### PR TITLE
Update Docs deployment to use single upload

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: Generate Documentation
+name: Docs
 
 on:
   pull_request:
@@ -25,14 +25,6 @@ jobs:
       with:
         name: mkdocs-site
         path: site
-
-    - name: Deploy Docs
-      if: github.event_name == 'push'
-      uses: JamesIves/github-pages-deploy-action@3.7.1
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: site
 
   ldoc:
     name: LDoc
@@ -63,11 +55,29 @@ jobs:
         name: ldoc-site
         path: site/api
 
+  deploy:
+    name: Deploy
+    if: github.event_name == 'push'
+    needs:
+    - mkdocs
+    - ldoc
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download MkDocs Build
+      uses: actions/download-artifact@v2
+      with:
+        name: mkdocs-site
+        path: site
+
+    - name: Download LDoc Build
+      uses: actions/download-artifact@v2
+      with:
+        name: ldoc-site
+        path: site/api
+
     - name: Deploy Docs
-      if: github.event_name == 'push'
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
-        FOLDER: site/api
-        TARGET_FOLDER: api
+        FOLDER: site


### PR DESCRIPTION
## Proposed changes
Adds a dependent deployment step that gathers artifacts and deploys in a single upload.

## Related issues
Fixes #38 by avoiding the conditions where the simultaneous gh-pages deployments fail.
